### PR TITLE
Revert "Update dependency com.google.devtools.ksp:symbol-processing-gradle-plugin to v2.2.21-RC-2.0.4"

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -4,7 +4,7 @@ androidx-compose-runtime = "1.9.3"
 dokka = "2.0.0"
 jbCompose = "1.10.0-alpha01"
 kotlin = "2.2.21-RC"
-ksp = "2.2.21-RC-2.0.4"
+ksp = "2.2.20-2.0.2"
 
 # These coordinates are othewise unused, but allow Renovate to understand the associated versions.
 [libraries]


### PR DESCRIPTION
Reverts JakeWharton/prerelease-testing#158

Breaks KotlinPoet. See https://github.com/square/kotlinpoet/pull/2215.