### PR TITLE
Switch JetBrains Copose coordinate to UI

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,6 +11,6 @@ ksp = "2.2.20-2.0.2"
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
 dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
-jetbrains-compose = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jbCompose" }
+jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jbCompose" }
 kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }


### PR DESCRIPTION
We no longer use the JetBrains Compose runtime, but some projects still rely on JetBrains Compose UI. They're all versioned the same (unlike AndroidX), so change the coordinate to reflect that parts we use.